### PR TITLE
Issue 7 (negative rounding problem) fix

### DIFF
--- a/src/main/java/de/miraisoft/ash2/mixin/InGameHudMixin.java
+++ b/src/main/java/de/miraisoft/ash2/mixin/InGameHudMixin.java
@@ -69,8 +69,7 @@ public class InGameHudMixin {
 
 		if (AshCommands.config.showCoords) {
 			matrixStack.push();
-			BlockPos blockPos = new BlockPos((int) cameraEntity.getX(),
-					(int) cameraEntity.getBoundingBox().getMin(Direction.Axis.Y), (int) cameraEntity.getZ());
+			BlockPos blockPos =  cameraEntity.getBlockPos();
 			if (AshCommands.config.conciseCoords) {
 				String direction = "";
 				if (AshCommands.config.showDirection) {


### PR DESCRIPTION
that (int) cast is the core problem.  This can be fixed by using round() instead, but cameraEntity already has a .getBlockPos, so just use that.